### PR TITLE
fix: Fixed "Path not found" under some distributions 

### DIFF
--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIPipelineComponent.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIPipelineComponent.java
@@ -57,8 +57,11 @@ public class DUUIPipelineComponent {
 
     private String getVersion() throws URISyntaxException, IOException {
         ClassLoader classLoader = DUUIPipelineComponent.class.getClassLoader();
-        String properties = Files.readString(Paths.get(classLoader.getResource("git.properties").toURI()));
-        return properties;
+        try {
+            return classLoader.getResourceAsStream("git.properties").toString();
+        } catch (NullPointerException e) {
+            throw new IOException("Could not find resource \"git.properties\"!", e);
+        }
     }
 
     public DUUIPipelineComponent() throws URISyntaxException, IOException {


### PR DESCRIPTION
The issue was caused by `Paths.get(classLoader.getResource().toURI())` used to get a property file in the classpath.

Now uses `classLoader.getResourceAsStream().toString()` wrapped in a try-catch for a NullPointerException.