### PR TITLE
Return Values from Lua Calls & Set Headers for POST Requests

### DIFF
--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/DUUIFallbackCommunicationLayer.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/DUUIFallbackCommunicationLayer.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 public class DUUIFallbackCommunicationLayer implements IDUUICommunicationLayer {
-    public void serialize(JCas jc, ByteArrayOutputStream out, Map<String,String> parameters, String sourceView) throws CompressorException, IOException, SAXException, CASException {
+    public SerializeOutput serialize(JCas jc, ByteArrayOutputStream out, Map<String,String> parameters, String sourceView) throws CompressorException, IOException, SAXException, CASException {
         JSONObject obj = new JSONObject();
         ByteArrayOutputStream arr = new ByteArrayOutputStream();
         XmiCasSerializer.serialize(jc.getView(sourceView).getCas(), null, arr);
@@ -33,6 +33,8 @@ public class DUUIFallbackCommunicationLayer implements IDUUICommunicationLayer {
         obj.put("compression","none");
         obj.put("params",parameters);
         out.write(obj.toString().getBytes(StandardCharsets.UTF_8));
+
+        return null;
     }
 
     public void deserialize(JCas jc, ByteArrayInputStream input, String targetView) throws IOException, SAXException {
@@ -48,8 +50,8 @@ public class DUUIFallbackCommunicationLayer implements IDUUICommunicationLayer {
     }
 
     @Override
-    public void serialize(JCas jc, ByteArrayOutputStream out, Map<String, String> parameters) throws CompressorException, IOException, SAXException, CASException {
-        serialize(jc, out, parameters, "_InitialView");
+    public SerializeOutput serialize(JCas jc, ByteArrayOutputStream out, Map<String, String> parameters) throws CompressorException, IOException, SAXException, CASException {
+        return serialize(jc, out, parameters, "_InitialView");
     }
 
     @Override

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIDockerDriver.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIDockerDriver.java
@@ -719,5 +719,10 @@ public class DUUIDockerDriver implements IDUUIDriverInterface {
             _component.withName(name);
             return this;
         }
+
+        public Component withRequestHeader(String key, String value)  {
+            _component.withRequestHeader(key, value);
+            return this;
+        }
     }
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIKubernetesDriver.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIKubernetesDriver.java
@@ -686,5 +686,10 @@ public class DUUIKubernetesDriver implements IDUUIDriverInterface {
             _component.withName(name);
             return this;
         }
+
+        public Component withRequestHeader(String key, String value)  {
+            _component.withRequestHeader(key, value);
+            return this;
+        }
     }
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIPipelineComponent.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIPipelineComponent.java
@@ -1,5 +1,6 @@
 package org.texttechnologylab.DockerUnifiedUIMAInterface.driver;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorOutputStream;
@@ -38,6 +39,7 @@ public class DUUIPipelineComponent {
     private int _ws_elements = 50;
 
     private List<String> _constraints = new ArrayList<>(0);
+    private HashMap<String, String> _request_headers = new HashMap<>();
 
     public static String compressionMethod = CompressorStreamFactory.XZ;
 
@@ -281,6 +283,31 @@ public class DUUIPipelineComponent {
             lst.push(arr.getString(i));
         }
         return lst;
+    }
+
+    /**
+     * Adds a key-value pair to the request headers for the current DUUIPipelineComponent.
+     * This method allows custom headers to be added to the request configuration.
+     *
+     * @param key the name of the header to be added
+     * @param value the value associated with the specified header name
+     * @throws RuntimeException if the component has already been finalized and is therefore immutable
+     */
+    public void withRequestHeader(String key, String value) {
+        if (_finalizedEncoded != null) {
+            throw new RuntimeException("DUUIPipelineComponent has already been finalized, it is immutable now!");
+        }
+        _request_headers.put(key, value);
+    }
+
+    /**
+     * Retrieves the request headers that have been set for this component.
+     *
+     * @return an {@link ImmutableMap} containing the request headers, where the keys are header names
+     *         and the values are the corresponding header values.
+     */
+    public ImmutableMap<String, String> getRequestHeaders() {
+        return ImmutableMap.copyOf(_request_headers);
     }
 
     public DUUIPipelineComponent withDockerAuth(String name, String password) {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIPodmanDriver.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIPodmanDriver.java
@@ -486,6 +486,11 @@ public class DUUIPodmanDriver implements IDUUIDriverInterface {
             _component.withName(name);
             return this;
         }
+
+        public DUUIPodmanDriver.Component withRequestHeader(String key, String value)  {
+            _component.withRequestHeader(key, value);
+            return this;
+        }
     }
 
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIRemoteDriver.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIRemoteDriver.java
@@ -130,6 +130,11 @@ public class DUUIRemoteDriver implements IDUUIDriverInterface {
             component.withName(name);
             return this;
         }
+
+        public Component withRequestHeader(String key, String value)  {
+            component.withRequestHeader(key, value);
+            return this;
+        }
     }
 
     public void setLuaContext(DUUILuaContext luaContext) {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUISwarmDriver.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUISwarmDriver.java
@@ -505,6 +505,11 @@ public class DUUISwarmDriver implements IDUUIDriverInterface {
             return this;
         }
 
+        public Component withRequestHeader(String key, String value)  {
+            component.withRequestHeader(key, value);
+            return this;
+        }
+
         public DUUIPipelineComponent build() {
             component.withDriver(DUUISwarmDriver.class);
             return component;

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIUIMADriver.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/DUUIUIMADriver.java
@@ -169,6 +169,11 @@ public class DUUIUIMADriver implements IDUUIDriverInterface {
             component.withName(name);
             return this;
         }
+
+        public Component withRequestHeader(String key, String value)  {
+            component.withRequestHeader(key, value);
+            return this;
+        }
     }
 
     public boolean canAccept(DUUIPipelineComponent component) throws InvalidXMLException, IOException, SAXException {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/IDUUIInstantiatedPipelineComponent.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/driver/IDUUIInstantiatedPipelineComponent.java
@@ -140,7 +140,10 @@ public interface IDUUIInstantiatedPipelineComponent {
 
         /// Process output of serialize() invocation
         // Merge serialize and user-defined request headers
-        final HashMap<String, String> request_headers = new HashMap<>(serializeOutput.headers);
+        final HashMap<String, String> request_headers = new HashMap<>();
+        if (serializeOutput.headers != null) {
+            request_headers.putAll(serializeOutput.headers);
+        }
         pipelineComponent.getRequestHeaders().forEach((key, value) -> {
             if (request_headers.containsKey(key) && !request_headers.get(key).equals(value)) {
                 System.out.printf(

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/lua/DUUILuaCommunicationLayer.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/lua/DUUILuaCommunicationLayer.java
@@ -4,6 +4,7 @@ import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.uima.cas.CASException;
 import org.apache.uima.jcas.JCas;
 import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaValue;
 import org.luaj.vm2.lib.jse.CoerceJavaToLua;
 import org.luaj.vm2.lib.jse.CoerceLuaToJava;
 import org.texttechnologylab.DockerUnifiedUIMAInterface.IDUUICommunicationLayer;
@@ -33,11 +34,7 @@ public class DUUILuaCommunicationLayer implements IDUUICommunicationLayer {
         _globalContext = globalContext;
     }
 
-    public void serialize(JCas jc, ByteArrayOutputStream out, Map<String,String> parameters) throws CompressorException, IOException, SAXException, CASException {
-        serialize(jc, out, parameters, "_InitialView");
-    }
-
-    public void serialize(JCas jc, ByteArrayOutputStream out, Map<String,String> parameters, String sourceView) throws CompressorException, IOException, SAXException, CASException {
+    public SerializeOutput serialize(JCas jc, ByteArrayOutputStream out, Map<String, String> parameters, String sourceView) throws CompressorException, IOException, SAXException, CASException {
         LuaTable params = new LuaTable();
         if (parameters != null) {
             for (String key : parameters.keySet()) {
@@ -45,13 +42,14 @@ public class DUUILuaCommunicationLayer implements IDUUICommunicationLayer {
             }
         }
 
-        _file.call("serialize",CoerceJavaToLua.coerce(jc.getView(sourceView)),CoerceJavaToLua.coerce(out), params);
+        LuaTable output = _file.call("serialize", CoerceJavaToLua.coerce(jc.getView(sourceView)), CoerceJavaToLua.coerce(out), params);
+
+        return new SerializeOutput(output);
     }
 
     public void deserialize(JCas jc, ByteArrayInputStream input) throws IOException, SAXException, CASException {
         deserialize(jc, input, "_InitialView");
     }
-
 
     public void deserialize(JCas jc, ByteArrayInputStream input, String targetView) throws IOException, SAXException, CASException {
 

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/lua/DUUILuaCommunicationLayer.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/lua/DUUILuaCommunicationLayer.java
@@ -42,7 +42,7 @@ public class DUUILuaCommunicationLayer implements IDUUICommunicationLayer {
             }
         }
 
-        LuaTable output = _file.call("serialize", CoerceJavaToLua.coerce(jc.getView(sourceView)), CoerceJavaToLua.coerce(out), params);
+        LuaValue output = _file.call("serialize", CoerceJavaToLua.coerce(jc.getView(sourceView)), CoerceJavaToLua.coerce(out), params);
 
         return new SerializeOutput(output);
     }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/lua/DUUILuaCompiledFile.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/lua/DUUILuaCompiledFile.java
@@ -26,24 +26,13 @@ public class DUUILuaCompiledFile {
      * @param funcName Name of the function in the LUA script to be invoked.
      * @param args     Any number of parameters to pass to the LUA function.
      * @return A {@link LuaTable} with any values returned by the invoked function
-     * @throws LuaError If the called method does not return <code>nil</code> or a table.
      */
-    LuaTable call(String funcName, LuaValue... args) {
-        LuaValue result;
+    LuaValue call(String funcName, LuaValue... args) {
         if (_sethook != null) {
-            result = callThreaded(funcName, args);
+            return callThreaded(funcName, args);
         } else {
-            // Use {@link LuaValue#invoke(LuaValue[])} to handle any number of arguments
-            result = _globals.get(funcName).invoke(args).arg1();
-        }
-
-        // Check if the invoked function returned a table
-        if (result.istable()) {
-            return result.checktable();
-        } else if (result.isnil()) {
-            return LuaTable.tableOf();
-        } else {
-            throw new LuaError("Expected Lua function \"" + funcName + "\" to return a table, but got: " + result.typename());
+            /// Use {@link LuaValue#invoke(LuaValue[])} to handle any number of arguments
+            return _globals.get(funcName).invoke(args).arg1();
         }
     }
 


### PR DESCRIPTION
This PR proposes some changes to enable passing additional data from `serialize` calls back to the component that called it and enabling setting request headers as specified in the returned `LuaTable` or as defined by users.

### Overview

1. Unified all variants of `DUUILuaCompiledFile.call` to a single variant that takes any number of arguments.
2. Added a `SerializeOutput` nested class to `IDUUICommunicationLayer` that processes the `LuaValue` returned from `serialize()` calls. If something was returned from `serialize()`, check if it is a table and process the values within (currently only `headers`). If it was not, throw a `LuaError`.
4. Added methods to `DUUIPipelineComponent`'s to set request headers in the pipeline definition.
5. Process headers from component and `SerializeOutput`, and set them for POST requests in `process()`.

### Tests

I tested this using a WIP component that requires request headers to be set, and it works perfectly fine.
I wasn't able to run the regular DUUI tests, though.
