### PR TITLE
New Reader class for ABBYY FineReader OCR Output

### DIFF
--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/AbbyyDocumentReader.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/AbbyyDocumentReader.java
@@ -1,0 +1,451 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy;
+
+import com.google.common.base.Strings;
+import de.tudarmstadt.ukp.dkpro.core.api.anomaly.type.Anomaly;
+import de.tudarmstadt.ukp.dkpro.core.api.anomaly.type.SuggestedAction;
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.uima.UIMARuntimeException;
+import org.apache.uima.UimaContext;
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.fit.component.JCasCollectionReader_ImplBase;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.ExternalResource;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.cas.FSArray;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.util.Progress;
+import org.dkpro.core.api.parameter.ComponentParameters;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.util.AntPathMatcher;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.FileType;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.MatchRules;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Patterns;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.FineReaderEventHandler;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements.*;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.monitoring.ProgressTracker;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.monitoring.ProgressTrackerRemaining;
+import org.texttechnologylab.annotation.ocr.abbyy.Document;
+import org.texttechnologylab.annotation.ocr.abbyy.Line;
+import org.texttechnologylab.annotation.ocr.abbyy.Page;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.*;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Reader class for ABBYY FineReader XMLs. Handles raw or compressed input files (GZip, BZip2, and XZ).
+ * Use {@link #PARAM_ROOT_PATTERNS PARAM_ROOT_PATTERNS} to define the root folders of documents within the
+ * {@link #PARAM_SOURCE_LOCATION PARAM_SOURCE_LOCATION}, and {@link #PARAM_FILE_PATTERNS PARAM_FILE_PATTERNS}
+ * to filter files within these directories.
+ * <p/>
+ * The CAS'es produced by this reader will have their {@link DocumentMetaData DocumentMetaData} set according to the
+ * root path. You may set the base URI using the {@link #PARAM_BASE_URI PARAM_BASE_URI}.
+ * It will replace the path prefix <emph>above</emph> the root path.
+ * The documents will have their {@link DocumentMetaData#setDocumentId DocumentId} set to the name of their respective
+ * root directory. You can als pass a {@link #PARAM_COLLECTION_ID collection ID} to be set.
+ * <p/>
+ * Each element parsed from the ABBYY FineReader files will have some additional metadata set in accordance with the
+ * BIOfid project's export structure (which in turn, reflects the Visual Library structure),
+ * i.e. the URI of a {@link Page#getPageUri() Page} elements will point to {@code $BASE_URI/$PAGE_NAME} where the
+ * {@code PAGE_NAME} is parsed from the file name (e.g. {@code 01_1234567.xml}).
+ */
+public class AbbyyDocumentReader extends JCasCollectionReader_ImplBase {
+
+    /**
+     * Location from which the input is read.
+     */
+    public static final String PARAM_SOURCE_LOCATION = ComponentParameters.PARAM_SOURCE_LOCATION;
+    @ConfigurationParameter(name = PARAM_SOURCE_LOCATION, mandatory = true)
+    private String sourceLocation;
+
+    /**
+     * A set of Ant-like include/exclude patterns. A pattern starts with {@link MatchRules#INCLUDE_PREFIX [+]}
+     * if it is an include pattern and with {@link MatchRules#EXCLUDE_PREFIX [-]} if it is an exclude pattern.
+     * The wildcard <code>&#47;**&#47;</code> can be used to address any number of sub-directories.
+     * The wildcard {@code *} can be used to a address a part of a name.
+     * <p/>
+     * This pattern is used to filter the <emph>directories</emph> considered document roots.
+     * If omitted, will include all directories in the {@link #PARAM_SOURCE_LOCATION sourceLocation}
+     * (equvialent to {@link #DEFAULT_ROOT_INCLUDE [+]*}).
+     */
+    public static final String PARAM_ROOT_PATTERNS = "rootPatterns";
+    @ConfigurationParameter(name = PARAM_ROOT_PATTERNS, mandatory = false)
+    private String[] rootPatterns;
+    public static final String DEFAULT_ROOT_INCLUDE = "*";
+
+    /**
+     * A set of Ant-like include/exclude patterns. A pattern starts with {@link MatchRules#INCLUDE_PREFIX [+]}
+     * if it is an include pattern and with {@link MatchRules#EXCLUDE_PREFIX [-]} if it is an exclude pattern.
+     * The wildcard <code>&#47;**&#47;</code> can be used to address any number of sub-directories.
+     * The wildcard {@code *} can be used to a address a part of a name.
+     * <p/>
+     * This pattern is used to filter the <emph>files</emph> considered as input.
+     * If omitted, will include all XML files in any sub-directory of the {@link #PARAM_SOURCE_LOCATION sourceLocation}
+     * (equvialent to {@link #DEFAULT_FILES_INCLUDE [+]**<code>/</code>*.xml}).
+     */
+    public static final String PARAM_FILE_PATTERNS = ComponentParameters.PARAM_PATTERNS;
+    @ConfigurationParameter(name = PARAM_FILE_PATTERNS, mandatory = false)
+    private String[] filePatterns;
+    public static final String DEFAULT_FILES_INCLUDE = "**/*.xml.*";
+
+    /**
+     * Overwrite the base URI of the parsed documents.
+     * If omitted, will default to the parent directory of the document root path.
+     */
+    public static final String PARAM_BASE_URI = "baseUri";
+    @ConfigurationParameter(name = PARAM_BASE_URI, mandatory = false)
+    private String baseUri;
+
+    /**
+     * If provided, {@link DocumentMetaData#setCollectionId(String) sets the DocumentMetaData.CollectionId}.
+     */
+    public static final String PARAM_COLLECTION_ID = "collectionId";
+    @ConfigurationParameter(name = PARAM_COLLECTION_ID, mandatory = false)
+    private String collectionId;
+
+    /**
+     * Name of optional external (UIMA) resource that contains the Locator for a (Spring)
+     * ResourcePatternResolver implementation for locating (spring) resources.
+     * <p/>
+     * Defaults to {@link PathMatchingResourcePatternResolver}.
+     */
+    public static final String KEY_RESOURCE_RESOLVER = "resolver";
+    @ExternalResource(key = KEY_RESOURCE_RESOLVER, mandatory = false)
+    private final ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+    /**
+     * Set this as the language of the produced documents. Default: {@code de}.
+     */
+    public static final String PARAM_LANGUAGE = ComponentParameters.PARAM_LANGUAGE;
+    @ConfigurationParameter(name = PARAM_LANGUAGE, mandatory = false, defaultValue = "de")
+    private String language;
+
+    /**
+     * If {@code true}, use LanguageTool spellcheck for anomaly detection. Currently broken so this parameter does nothing.
+     */
+    public static final String PARAM_ENABLE_GARBAGE_HEURISTICS = "enableGarbageHeuristics";
+    @ConfigurationParameter(name = PARAM_ENABLE_GARBAGE_HEURISTICS, mandatory = false, defaultValue = "false")
+    protected Boolean enableGarbageHeuristics;
+
+    /**
+     * Some characters may be escaped HTML sequences. Set this parameter to true to unescape them during parsing.
+     */
+    public static final String PARAM_UNESCAPE_HTML = "pUnescapeHTML";
+    @ConfigurationParameter(name = PARAM_UNESCAPE_HTML, mandatory = false, defaultValue = "true")
+    protected Boolean pUnescapeHTML;
+
+    /**
+     * The frequency with which read documents are logged.
+     * <p>
+     * Set to 0 or negative values to deactivate logging.
+     */
+    public static final String PARAM_LOG_FREQ = "logFreq";
+    @ConfigurationParameter(name = PARAM_LOG_FREQ, mandatory = true, defaultValue = "1000")
+    private int logFreq;
+
+    /**
+     * Unless set, errors during XML parsing will be logged but processing will continue with next document.
+     */
+    public static final String PARAM_STOP_AT_FIRST_ERROR = "stopAtFirstError";
+    @ConfigurationParameter(name = PARAM_STOP_AT_FIRST_ERROR, mandatory = true, defaultValue = "false")
+    private boolean stopAtFirstError;
+
+    private ProgressTracker progressDocuments;
+    private ProgressTrackerRemaining progressFiles;
+
+    private TreeMap<Path, List<Path>> resourceMap;
+    private Iterator<Map.Entry<Path, List<Path>>> nestedResourceIterator;
+
+    private final AntPathMatcher matcher = new AntPathMatcher();
+    private SAXParser saxParser;
+
+    @Override
+    public void initialize(UimaContext context) throws ResourceInitializationException {
+        super.initialize(context);
+
+        if (!Path.of(sourceLocation).toFile().isDirectory()) {
+            throw new ResourceInitializationException(
+                    new IOException(
+                            String.format(
+                                    "PARAM_SOURCE_LOCATION does not point to a valid directory: %s",
+                                    sourceLocation
+                            )
+                    )
+            );
+        }
+
+        if (Strings.isNullOrEmpty(this.baseUri)) {
+            this.baseUri = sourceLocation;
+        }
+        if (!this.baseUri.endsWith("/")) {
+            this.baseUri += "/";
+        }
+
+        try {
+            saxParser = SAXParserFactory.newInstance().newSAXParser();
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new ResourceInitializationException(e);
+        }
+
+        MatchRules rootRules = new MatchRules(rootPatterns, DEFAULT_ROOT_INCLUDE);
+        MatchRules fileRules = new MatchRules(filePatterns, DEFAULT_FILES_INCLUDE);
+
+        List<Path> rootPaths = scan(sourceLocation, rootRules, FileType.OnlyDirectories);
+
+        resourceMap = new TreeMap<>();
+        for (Path rootPath : rootPaths) {
+            List<Path> filePaths = scan(rootPath.toString(), fileRules, FileType.OnlyFiles);
+            if (!filePaths.isEmpty()) {
+                resourceMap.put(rootPath, filePaths);
+            }
+        }
+        nestedResourceIterator = resourceMap.entrySet().iterator();
+
+        progressDocuments = new ProgressTracker(rootPaths.size(), "documents");
+        progressFiles = new ProgressTrackerRemaining(
+                resourceMap.values().stream().map(List::size).reduce(0, Integer::sum),
+                "files"
+        );
+    }
+
+    private List<Path> scan(String basePath, MatchRules matchRules, FileType fileType) {
+        final String basePathURI = Path.of(Utils.ensureSuffix(basePath, "/")).toFile().toURI().toString();
+
+        ArrayList<Path> paths = new ArrayList<>();
+        for (String include : matchRules.includes) {
+            try {
+                nextResource:
+                for (Resource resource : resolver.getResources(basePathURI + include)) {
+                    File file = resource.getFile();
+
+                    switch (fileType) {
+                        case FileType.OnlyFiles:
+                            if (!file.isFile())
+                                continue;
+                            break;
+                        case FileType.OnlyDirectories:
+                            if (!file.isDirectory())
+                                continue;
+                            break;
+                        case FileType.FilesOrDirectories:
+                            if (!file.isFile() && !file.isDirectory())
+                                continue;
+                            break;
+                    }
+
+                    Path path = file.toPath();
+                    if (matchRules.hasExcludes()) {
+                        String rest = path.toString().substring(basePathURI.length());
+                        for (String exclude : matchRules.excludes) {
+                            if (matcher.match(exclude, rest))
+                                continue nextResource;
+                        }
+                    }
+                    paths.add(path);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        paths.sort(Path::compareTo);
+        return paths;
+    }
+
+    @Override
+    public boolean hasNext() throws IOException, CollectionException {
+        return nestedResourceIterator.hasNext();
+    }
+
+    @Override
+    public Progress[] getProgress() {
+        return new ProgressTracker[]{progressDocuments, progressFiles};
+    }
+
+    @Override
+    public void getNext(JCas jCas) throws IOException, CollectionException {
+        if (!nestedResourceIterator.hasNext()) {
+            throw new CollectionException(new NoSuchElementException("No further documents to process!"));
+        }
+
+        Map.Entry<Path, List<Path>> entry = nestedResourceIterator.next();
+
+        initCas(jCas, entry.getKey());
+
+        long lastFileProgress = progressFiles.getCompleted();
+        try {
+            process(jCas, entry.getValue());
+        } catch (IOException e) {
+            if (stopAtFirstError) {
+                throw e;
+            } else {
+                getLogger().warn("Caught IOException while processing XMLs of document {}; continuing as `stopAtFirstError` is set.", entry.getKey());
+                getLogger().error("Ignored {} caused by {}", e, e.getCause().toString());
+
+                // Remove further files of this document from progress total
+                long completedOfThisDocument = progressFiles.getCompleted() - lastFileProgress;
+                long missingForThisDocument = entry.getValue().size() - completedOfThisDocument;
+                progressFiles.setTotal(progressFiles.getTotal() - missingForThisDocument);
+            }
+        }
+
+        progressDocuments.inc();
+        if (logFreq > 0) {
+            getLogger().info("{}, {}", progressDocuments, progressFiles);
+        }
+    }
+
+    private void initCas(JCas jCas, Path rootPath) {
+        String rootName = rootPath.toFile().getName();
+        String suffix = rootPath.toString().substring(sourceLocation.length());
+        if (suffix.startsWith("/")) {
+            suffix = suffix.substring(1);
+        }
+        String documentUri = baseUri + suffix;
+
+        // Set the DKPro Core document metadata
+        DocumentMetaData docMetaData = DocumentMetaData.create(jCas);
+        docMetaData.setDocumentTitle(rootName);
+        docMetaData.setDocumentId(suffix);
+
+        docMetaData.setDocumentBaseUri(baseUri);
+        docMetaData.setDocumentUri(documentUri);
+
+        if (!Strings.isNullOrEmpty(collectionId)) {
+            docMetaData.setCollectionId(collectionId);
+        }
+
+        jCas.setDocumentLanguage(language);
+    }
+
+    public void process(JCas jCas, List<Path> files) throws IOException, CollectionException {
+        FineReaderEventHandler.ParsedDocument parsedDocument = parseFiles(files);
+
+        // Build SOFA string, remove HTML escapes
+        String text = parsedDocument.tokens.stream().map(AbbyyToken::toString).collect(Collectors.joining(""));
+        if (pUnescapeHTML) {
+            text = StringEscapeUtils.unescapeHtml(text);
+        }
+        jCas.setDocumentText(text);
+        jCas.setDocumentLanguage(language);
+
+        Document ocrDocument = new Document(jCas);
+        ocrDocument.setBegin(0);
+        ocrDocument.setEnd(jCas.getDocumentText().length());
+        jCas.addFsToIndexes(ocrDocument);
+
+        // Add parsed elements to CAS
+        for (AbbyyPage page : parsedDocument.pages) {
+            jCas.addFsToIndexes(page.into(jCas));
+        }
+        for (AbbyyBlock block : parsedDocument.blocks) {
+            jCas.addFsToIndexes(block.into(jCas));
+        }
+        for (AbbyyParagraph paragraph : parsedDocument.paragraphs) {
+            jCas.addFsToIndexes(paragraph.into(jCas));
+        }
+        for (AbbyyLine line : parsedDocument.lines) {
+            Line ocrLine = (Line) line.into(jCas);
+            jCas.addFsToIndexes(ocrLine);
+
+            if (enableGarbageHeuristics) {
+                detectAnomaly(jCas, ocrLine);
+            }
+        }
+        for (AbbyyToken token : parsedDocument.tokens) {
+            if (!token.isSpace()) {
+                jCas.addFsToIndexes(token.into(jCas));
+            }
+        }
+    }
+
+    private FineReaderEventHandler.ParsedDocument parseFiles(List<Path> files) throws IOException {
+        FineReaderEventHandler fineReaderEventHandler = new FineReaderEventHandler();
+        for (Path path : files) {
+            String fileName = path.toFile().getName();
+
+            String prefix = fileName.substring(0, fileName.indexOf("_")).trim();
+            try {
+                fineReaderEventHandler.setNextPageId(Integer.parseInt(prefix));
+            } catch (NumberFormatException ignored) {
+                // ignored
+            }
+
+            String suffix = fileName.substring(fileName.indexOf("_") + 1);
+            suffix = suffix.substring(0, suffix.indexOf(".")).trim();
+            fineReaderEventHandler.setNextPageUri(baseUri + suffix);
+
+            try {
+                saxParser.parse(openInputStream(path), fineReaderEventHandler);
+            } catch (SAXException e) {
+                throw new IOException(path.toString(), e);
+            }
+            progressFiles.inc();
+            if (logFreq > 0 && progressFiles.getCompleted() % logFreq == 0) {
+                getLogger().info("{}, {}", progressDocuments, progressFiles);
+            }
+        }
+
+        return fineReaderEventHandler.getParsedDocument();
+    }
+
+    private static InputStream openInputStream(Path path) throws IOException {
+        FileInputStream fileInputStream = new FileInputStream(path.toFile());
+        String pathString = path.toString();
+        try {
+            if (pathString.endsWith(".gz")) {
+                return new CompressorStreamFactory().createCompressorInputStream(CompressorStreamFactory.GZIP, fileInputStream);
+            } else if (pathString.endsWith(".bz2")) {
+                return new CompressorStreamFactory().createCompressorInputStream(CompressorStreamFactory.BZIP2, fileInputStream);
+            } else if (pathString.endsWith(".xz")) {
+                return new CompressorStreamFactory().createCompressorInputStream(CompressorStreamFactory.XZ, fileInputStream);
+            } else {
+                return fileInputStream;
+            }
+        } catch (CompressorException impossible) {
+            throw new UIMARuntimeException(impossible);
+        }
+    }
+
+    private void detectAnomaly(JCas jCas, Annotation annotation) {
+        try {
+            final String coveredText = annotation.getCoveredText();
+
+            final boolean isNumberTable = Patterns.weirdNumberTable.matcher(coveredText).matches();
+            boolean isGarbageLine = !isNumberTable || Patterns.yearPattern.matcher(coveredText).matches();
+
+            final boolean isLetterTable = Patterns.weirdLetterTable.matcher(coveredText).matches();
+            isGarbageLine &= !isLetterTable;
+
+            if (!isGarbageLine) {
+                String description = String.format("weirdNumberTable:%b, weirdLetterTable:%b", isNumberTable, isLetterTable);
+                tagAnomaly(jCas, description, annotation.getBegin(), annotation.getEnd(), "ABBYY:" + annotation.getType().getName(), "");
+            }
+        } catch (Exception e) {
+            getLogger().error(e.toString());
+        }
+    }
+
+    private void tagAnomaly(JCas jCas, String description, int begin, int end, String anomalyType, String replacement) {
+        Anomaly anomaly = new Anomaly(jCas, begin, end);
+        anomaly.setCategory(anomalyType);
+        anomaly.setDescription(description);
+        SuggestedAction suggestedAction = new SuggestedAction(jCas);
+        suggestedAction.setReplacement(replacement);
+        FSArray<SuggestedAction> fsArray = new FSArray<>(jCas, 1);
+        fsArray.set(0, suggestedAction);
+        anomaly.setSuggestions(fsArray);
+        jCas.addFsToIndexes(anomaly);
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/AbbyyDocumentReader.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/AbbyyDocumentReader.java
@@ -218,18 +218,25 @@ public class AbbyyDocumentReader extends JCasCollectionReader_ImplBase {
     protected Boolean addTokens;
 
     /**
-     * If set {@code true}, enable heuristics to detect "garbage" lines in OCR output.
+     * If set to {@code true}, enable heuristics to detect "garbage" lines in OCR output.
      */
     public static final String PARAM_ENABLE_GARBAGE_HEURISTICS = "enableGarbageHeuristics";
     @ConfigurationParameter(name = PARAM_ENABLE_GARBAGE_HEURISTICS, mandatory = false, defaultValue = "false")
     protected Boolean enableGarbageHeuristics;
 
     /**
-     * Unless set {@code false}, HTML escaped characters in the OCR output will be unescaped.
+     * Unless set to {@code false}, HTML escaped characters in the OCR output will be unescaped.
      */
     public static final String PARAM_UNESCAPE_HTML = "unescapeHTML";
     @ConfigurationParameter(name = PARAM_UNESCAPE_HTML, mandatory = false, defaultValue = "true")
     protected Boolean unescapeHTML;
+
+    /**
+     * Unless set to {@code false}, all consecutive whitespace characters will be replaced by a single regular whitespace.
+     */
+    public static final String PARAM_UNIFY_WHITESPACES = "unifyWhitespaces";
+    @ConfigurationParameter(name = PARAM_UNIFY_WHITESPACES, mandatory = false, defaultValue = "true")
+    protected Boolean unifyWhitespaces;
 
     /**
      * The frequency with which read documents are logged.
@@ -501,6 +508,8 @@ public class AbbyyDocumentReader extends JCasCollectionReader_ImplBase {
 
     private FineReaderEventHandler.ParsedDocument parseFiles(List<Path> files) throws IOException, CollectionException {
         FineReaderEventHandler fineReaderEventHandler = new FineReaderEventHandler();
+        fineReaderEventHandler.unifyWhitespaces = this.unifyWhitespaces;
+
         for (Path path : files) {
             String fileName = path.toFile().getName();
 

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/AbbyyDocumentReader.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/AbbyyDocumentReader.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
  * <p/>
  * Each element parsed from the ABBYY FineReader files will have some additional metadata set in accordance with the
  * BIOfid project's export structure (which in turn, reflects the Visual Library structure),
- * i.e. the URI of a {@link Page#getPageUri() Page} elements will point to {@code $BASE_URI/$PAGE_NAME} where the
+ * i.e. the URI of a {@link Page#getUri() Page} elements will point to {@code $BASE_URI/$PAGE_NAME} where the
  * {@code PAGE_NAME} is parsed from the file name (e.g. {@code 01_1234567.xml}).
  */
 public class AbbyyDocumentReader extends JCasCollectionReader_ImplBase {
@@ -375,16 +375,17 @@ public class AbbyyDocumentReader extends JCasCollectionReader_ImplBase {
         for (Path path : files) {
             String fileName = path.toFile().getName();
 
-            String prefix = fileName.substring(0, fileName.indexOf("_")).trim();
+            String pageIndex = fileName.substring(0, fileName.indexOf("_")).trim();
             try {
-                fineReaderEventHandler.setNextPageId(Integer.parseInt(prefix));
+                fineReaderEventHandler.setNextPageIndex(Integer.parseInt(pageIndex));
             } catch (NumberFormatException ignored) {
                 // ignored
             }
 
-            String suffix = fileName.substring(fileName.indexOf("_") + 1);
-            suffix = suffix.substring(0, suffix.indexOf(".")).trim();
-            fineReaderEventHandler.setNextPageUri(baseUri + suffix);
+            String pageId = fileName.substring(fileName.indexOf("_") + 1);
+            pageId = pageId.substring(0, pageId.indexOf(".")).trim();
+            fineReaderEventHandler.setNextPageId(pageId);
+            fineReaderEventHandler.setNextPageUri(baseUri + pageId);
 
             try {
                 saxParser.parse(openInputStream(path), fineReaderEventHandler);

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/FileType.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/FileType.java
@@ -1,0 +1,7 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils;
+
+public enum FileType {
+        OnlyFiles,
+        OnlyDirectories,
+        FilesOrDirectories,
+    }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/MatchRules.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/MatchRules.java
@@ -1,0 +1,39 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils;
+
+import org.apache.uima.resource.ResourceInitializationException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MatchRules {
+    public static final String INCLUDE_PREFIX = "[+]";
+    public static final String EXCLUDE_PREFIX = "[-]";
+
+        public final List<String> includes = new ArrayList<>();
+        public final List<String> excludes = new ArrayList<>();
+
+        public MatchRules(String[] patterns, String defaultInclude) throws ResourceInitializationException {
+            if (patterns != null) {
+                for (String pattern : patterns) {
+                    if (pattern.startsWith(INCLUDE_PREFIX)) {
+                        includes.add(pattern.substring(INCLUDE_PREFIX.length()));
+                    } else if (pattern.startsWith(EXCLUDE_PREFIX)) {
+                        excludes.add(pattern.substring(EXCLUDE_PREFIX.length()));
+                    } else if (pattern.matches("^\\[.\\].*")) {
+                        throw new ResourceInitializationException(new IllegalArgumentException(
+                                "Patterns have to start with " + INCLUDE_PREFIX + " or "
+                                        + EXCLUDE_PREFIX + "."));
+                    } else {
+                        includes.add(pattern);
+                    }
+                }
+            }
+            if (includes.isEmpty()) {
+                includes.add(defaultInclude);
+            }
+        }
+
+        public boolean hasExcludes() {
+            return !excludes.isEmpty();
+        }
+    }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/Patterns.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/Patterns.java
@@ -1,0 +1,20 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils;
+
+import java.util.regex.Pattern;
+
+public class Patterns {
+        public static final Pattern weirdNumberTable = Pattern.compile("^[\\t \\d\\pP\\pS]+$", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern weirdLetterTable = Pattern.compile("^(\\S{1,2} )+$", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern yearPattern = Pattern.compile("^[ \\t]*.?\\pN{4}.?[ \\t]*$", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern letterPattern = Pattern.compile("[\\p{Alpha} ,.\\-]", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern otherPattern = Pattern.compile("[^\\p{Alpha} ,.\\-]", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern alnumPattern = Pattern.compile("[\\p{Alnum} ,.\\-]", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern nonAlnumPattern = Pattern.compile("[^\\p{Alnum} ,.\\-]", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern wordPattern = Pattern.compile("(?:[\\p{Z}\\-_]|^)(?:[\\p{L}]+|[\\p{Nd}]+)|(?:[\\p{L}]+|[\\p{Nd}]+)(?:[\\p{Zs}\\-_]|[\\n\\r\\f]$)", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern spacePattern = Pattern.compile("[ \\t]", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern tokenPattern = Pattern.compile("(?:[\\p{Z}]|^)[\\p{L}\\p{P}\\p{Sm}\\p{N}\\p{Sc}♂♀¬°½±^]+|[\\p{L}\\p{P}\\p{Sm}\\p{N}\\p{Sc}♂♀¬°½±^]+(?:[\\p{Zs}]|[\\n\\r\\f]$)",
+                Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern allNonSpacePattern = Pattern.compile("[^\\p{Z}]", Pattern.UNICODE_CHARACTER_CLASS);
+        public static final Pattern nonGarbageLine = Pattern.compile("^[\\w\\p{Z}♂♀¬°½±]{3,}$|^[\\w\\p{Z}\\p{P}\\p{Sm}\\p{N}\\p{Sc}♂♀¬°½±^]{5,}$|^[\\p{Z}]*$|^[\\p{N}\\p{Punct}\\p{Z}]+$", Pattern.UNICODE_CHARACTER_CLASS);
+
+    }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/Utils.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/Utils.java
@@ -1,0 +1,66 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils;
+
+import com.google.common.base.Strings;
+
+public class Utils {
+    public static int parseInt(String s) {
+        return Strings.isNullOrEmpty(s) ? 0 : Integer.parseInt(s);
+    }
+
+    public static int parseIntOr(String s, int defaultValue) {
+        return Strings.isNullOrEmpty(s) ? defaultValue : Integer.parseInt(s);
+    }
+
+    public static float parseFloat(String s) {
+        return Strings.isNullOrEmpty(s) ? 0f : Float.parseFloat(s);
+    }
+
+    public static boolean parseBoolean(String s) {
+        return !Strings.isNullOrEmpty(s) && Boolean.parseBoolean(s);
+    }
+
+    public static String ensureSuffix(String string, String suffix) {
+        if (string.endsWith(suffix)) {
+            return string;
+        } else {
+            return string + suffix;
+        }
+    }
+
+//    public static HashSet<String> loadDict(String pDictPath) throws IOException {
+//        HashSet<String> dict = new HashSet<>();
+//        if (pDictPath != null) {
+//            try (BufferedReader br = new BufferedReader(new FileReader(new File(pDictPath)))) {
+//                dict = br.lines().map(String::trim).collect(Collectors.toCollection(HashSet::new));
+//            }
+//        }
+//        return dict;
+//    }
+
+//    public static Optional<String> getCommonPathPrefix(ArrayList<String> inputFiles) {
+//        String first = inputFiles.getFirst();
+//        Path commonPath = Paths.get(first);
+//        if (!commonPath.toFile().isDirectory()) {
+//            commonPath = commonPath.getParent();
+//        }
+//        while (commonPath != null) {
+//            final String currentPath = commonPath.toString();
+//            if (inputFiles.stream().allMatch(p -> p.startsWith(currentPath))) {
+//                return Optional.of(currentPath);
+//            }
+//            commonPath = commonPath.getParent();
+//        }
+//
+//        return Optional.empty();
+//    }
+
+//    public static ArrayList<File> getFilesInFileTree(File parent) {
+//        final ArrayList<File> files = new ArrayList<>();
+//        for (File file : Files.fileTreeTraverser().preOrderTraversal(parent)) {
+//            if (file.isFile()) {
+//                files.add(file);
+//            }
+//        }
+//        return files;
+//    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/Utils.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/Utils.java
@@ -1,6 +1,7 @@
 package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils;
 
 import com.google.common.base.Strings;
+import org.apache.commons.lang.StringUtils;
 
 public class Utils {
     public static int parseInt(String s) {
@@ -16,7 +17,11 @@ public class Utils {
     }
 
     public static boolean parseBoolean(String s) {
-        return !Strings.isNullOrEmpty(s) && Boolean.parseBoolean(s);
+        return !Strings.isNullOrEmpty(s) && (
+                StringUtils.isNumeric(s) && Integer.parseInt(s) > 0
+                ||
+                Boolean.parseBoolean(s)
+        );
     }
 
     public static String ensureSuffix(String string, String suffix) {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/bb/Rect.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/bb/Rect.java
@@ -1,0 +1,4 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.bb;
+
+public record Rect(int top, int right, int bottom, int left) {
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/bb/RelativeBoundingBox.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/utils/bb/RelativeBoundingBox.java
@@ -1,0 +1,96 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.bb;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RelativeBoundingBox {
+    public final float top;
+    public final float right;
+    public final float bottom;
+    public final float left;
+
+    public static RelativeBoundingBox fromString(String value) {
+        List<Float> values = Arrays.stream(value.split(",")).map(String::trim).map(Float::parseFloat).toList();
+        return switch (values.size()) {
+            case 1 -> new RelativeBoundingBox(values.getFirst());
+            case 2 -> new RelativeBoundingBox(values.get(0), values.get(1));
+            case 3 -> new RelativeBoundingBox(values.get(0), values.get(1), values.get(2));
+            case 4 -> new RelativeBoundingBox(values.get(0), values.get(1), values.get(2), values.get(3));
+            default -> throw new IllegalArgumentException("Invalid value " + value);
+        };
+    }
+
+    public RelativeBoundingBox(float value) {
+        this.top = value;
+        this.right = 100 - value;
+        this.bottom = 100 - value;
+        this.left = value;
+        checkBounds();
+    }
+
+    public RelativeBoundingBox(float topBottom, float rightLeft) {
+        this.top = topBottom;
+        this.right = 100 - rightLeft;
+        this.bottom = 100 - topBottom;
+        this.left = rightLeft;
+        checkBounds();
+    }
+
+    public RelativeBoundingBox(float top, float rightLeft, float bottom) {
+        this.top = top;
+        this.right = 100 - rightLeft;
+        this.bottom = 100 - bottom;
+        this.left = rightLeft;
+        checkBounds();
+    }
+
+    public RelativeBoundingBox(float top, float right, float bottom, float left) {
+        this.top = top;
+        this.right = 100 - right;
+        this.bottom = 100 - bottom;
+        this.left = left;
+        checkBounds();
+    }
+
+    private void checkBounds() {
+        if (!(0 < top || top < 100 || 0 < right || right < 100 || 0 < bottom || bottom < 100 || 0 < left || left < 100)) {
+            throw new IllegalArgumentException("Bounds must be in range [0, 100]");
+        }
+        if (top > bottom) {
+            throw new IllegalArgumentException("top bound must be smaller than bottom bound");
+        }
+        if (left > right) {
+            throw new IllegalArgumentException("left bound must be smaller than right bound");
+        }
+    }
+
+    public class DocumentChecker {
+        private final float width;
+        private final float height;
+
+        public DocumentChecker(int width, int height) {
+            this.width = (float) width;
+            this.height = (float) height;
+        }
+
+        public boolean contains(Rect rect) {
+            float fTop = rect.top() / height * 100;
+            float fRight = rect.right() / width * 100;
+            float fBottom = rect.bottom() / height * 100;
+            float fLeft = rect.left() / width * 100;
+            return (
+                    fTop >= top
+            ) && (
+                    fRight <= right
+            ) && (
+                    fBottom <= bottom
+            ) && (
+                    fLeft >= left
+            );
+        }
+    }
+
+    public DocumentChecker checker(int width, int height) {
+        return new DocumentChecker(width, height);
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
@@ -205,7 +205,7 @@ public class FineReaderEventHandler extends DefaultHandler {
             tokens.add(currToken);
         }
         currToken = new AbbyyToken();
-        currToken.setEnd(textLength);
+        currToken.setStart(textLength);
     }
 
     public void setNextPageId(String pageId) {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
@@ -64,7 +64,6 @@ public class FineReaderEventHandler extends DefaultHandler {
             case "block":
                 currBlock = new AbbyyBlock(attributes);
                 currBlock.setStart(textLength);
-                currBlock.valid = currBlock.isText();
 
                 currChar = null;
                 break;

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
@@ -1,0 +1,268 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml;
+
+import com.google.common.collect.ImmutableList;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements.*;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+
+public class FineReaderEventHandler extends DefaultHandler {
+    // Pages
+    public ArrayList<AbbyyPage> pages = new ArrayList<>();
+    private AbbyyPage currPage = null;
+    private String nextPageUri = null;
+    private Integer nextPageId = null;
+
+    // Block
+    public ArrayList<AbbyyBlock> blocks = new ArrayList<>();
+    private AbbyyBlock currBlock = null;
+
+    // Paragraphs
+    public ArrayList<AbbyyParagraph> paragraphs = new ArrayList<>();
+    private AbbyyParagraph currParagraph = null;
+
+    // Lines
+    public ArrayList<AbbyyLine> lines = new ArrayList<>();
+    private AbbyyLine currLine = null;
+
+    // Token
+    public ArrayList<AbbyyToken> tokens = new ArrayList<>();
+    private AbbyyToken currToken = new AbbyyToken();
+    public int blockTopMin = 0;
+    public int charLeftMax = Integer.MAX_VALUE;
+
+    // Switches
+    public boolean lastTokenWasSpace = false;
+    private boolean lastTokenWasHyphen = false;
+
+    // Chars
+    private AbbyyChar currChar = null;
+
+    // Document Text
+    private int textLength = 0;
+
+    private static final Pattern spacePattern = Pattern.compile("[\\s]+", Pattern.UNICODE_CHARACTER_CLASS);
+    private static final Pattern nonWordCharacter = Pattern.compile("[^\\p{Alnum}\\-¬]+", Pattern.UNICODE_CHARACTER_CLASS);
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        switch (qName) {
+            case "page":
+                currPage = new AbbyyPage(attributes);
+                currPage.setStart(textLength);
+                getNextPageId().ifPresent(currPage::setPageId);
+                getNextPageUri().ifPresent(currPage::setPageUri);
+                break;
+            case "block":
+                currBlock = new AbbyyBlock(attributes);
+                currBlock.setStart(textLength);
+                currBlock.valid = currBlock.isText();
+
+                currChar = null;
+                break;
+            case "text":
+                break;
+            case "par":
+                currParagraph = new AbbyyParagraph(attributes);
+                currParagraph.setStart(textLength);
+                break;
+            case "line":
+                currLine = new AbbyyLine(attributes);
+                currLine.setStart(textLength);
+
+                break;
+            case "formatting":
+                if (currLine != null)
+                    currLine.setFormat(new AbbyyFormat(attributes));
+                break;
+            case "charParams":
+                String wordStart = attributes.getValue("wordStart");
+
+                if ("true".equals(wordStart) && !lastTokenWasHyphen) {
+                    pushCurrToken();
+                }
+
+                currChar = new AbbyyChar(attributes);
+                break;
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        switch (qName) {
+            case "page":
+                if (currPage != null) {
+                    currPage.setEnd(textLength);
+                    pages.add(currPage);
+                }
+                currPage = null;
+                break;
+            case "block":
+                addSpace();
+                if (currBlock != null) {
+                    currBlock.setEnd(textLength);
+                    blocks.add(currBlock);
+                }
+                currBlock = null;
+                break;
+            case "text":
+            case "par":
+                addSpace();
+                if (currParagraph != null) {
+                    currParagraph.setEnd(textLength);
+                    paragraphs.add(currParagraph);
+                }
+                currParagraph = null;
+                break;
+            case "line":
+                addSpace();
+                if (currLine != null) {
+                    currLine.setEnd(textLength);
+                    lines.add(currLine);
+                }
+                currLine = null;
+        }
+        currChar = null;
+    }
+
+    private void setEnd(IIntoAnnotation annotation) {
+        if (annotation != null) {
+            annotation.setEnd(textLength);
+        }
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        if (currChar != null) {
+            String text = new String(ch, start, length);
+
+            if (spacePattern.matcher(text).matches()) {
+                addSpace();
+            } else if (nonWordCharacter.matcher(text).matches()) {
+                addNonWordToken(currChar, text);
+            } else {
+                addWordToken(text);
+            }
+        }
+        currChar = null;
+    }
+
+    private void addSpace() {
+        // Do not add spaces if the preceding token is a space, the ¬ hyphenation character or there has not been any token
+        if (lastTokenWasSpace || lastTokenWasHyphen || currToken == null)
+            return;
+
+        // If the current token already contains characters, create a new token for the space
+        pushCurrToken();
+
+        // Add the space character and increase token count
+        tokens.add(AbbyyToken.space());
+        textLength++;
+        lastTokenWasSpace = true;
+    }
+
+    private void addNonWordToken(AbbyyChar abbyyChar, String text) {
+        // If the current token already contains characters, create a new token for the non-word token
+        pushCurrToken();
+
+        lastTokenWasSpace = false;
+        lastTokenWasHyphen = false;
+
+        currToken.addChar(abbyyChar, text);
+        textLength += text.length();
+
+        pushCurrToken();
+    }
+
+    private void addWordToken(String text) {
+        // Add a new subtoken if there has been a ¬ and it was followed by a character
+        if (lastTokenWasHyphen && !lastTokenWasSpace) {
+            currToken.addSubToken();
+        }
+        lastTokenWasSpace = false;
+
+        // The hyphen character ¬ does not contribute to the total character count
+        if (text.equals("¬")) {
+            lastTokenWasHyphen = true;
+        } else {
+            lastTokenWasHyphen = false;
+            currToken.addChar(currChar, text);
+            textLength += text.length();
+        }
+    }
+
+    private void pushCurrToken() {
+        if (currToken.length() > 0) {
+            currToken.setEnd(textLength);
+            tokens.add(currToken);
+        }
+        currToken = new AbbyyToken();
+        currToken.setEnd(textLength);
+    }
+
+    public void setNextPageId(int pageId) {
+        this.nextPageId = pageId;
+    }
+
+    private Optional<Integer> getNextPageId() {
+        if (nextPageId == null) {
+            return Optional.empty();
+        }
+        return Optional.of(nextPageId);
+    }
+
+    public void setNextPageUri(String pageUri) {
+        this.nextPageUri = pageUri;
+    }
+
+    private Optional<String> getNextPageUri() {
+        if (nextPageUri == null) {
+            return Optional.empty();
+        }
+        return Optional.of(nextPageUri);
+    }
+
+    public static class ParsedDocument {
+        final public ImmutableList<AbbyyPage> pages;
+        final public ImmutableList<AbbyyBlock> blocks;
+        final public ImmutableList<AbbyyParagraph> paragraphs;
+        final public ImmutableList<AbbyyLine> lines;
+        final public ImmutableList<AbbyyToken> tokens;
+        final public boolean lastTokenWasSpace;
+
+        public ParsedDocument(
+                List<AbbyyPage> pages,
+                List<AbbyyBlock> blocks,
+                List<AbbyyParagraph> paragraphs,
+                List<AbbyyLine> lines,
+                List<AbbyyToken> tokens,
+                boolean lastTokenWasSpace
+        ) {
+            this.pages = ImmutableList.copyOf(pages);
+            this.blocks = ImmutableList.copyOf(blocks);
+            this.paragraphs = ImmutableList.copyOf(paragraphs);
+            this.lines = ImmutableList.copyOf(lines);
+            this.tokens = ImmutableList.copyOf(tokens);
+            this.lastTokenWasSpace = lastTokenWasSpace;
+        }
+    }
+
+    public ParsedDocument getParsedDocument() {
+        for (String elementName : new String[]{"page", "block", "text", "par", "line"}) {
+            try {
+                endElement(null, null, elementName);
+            } catch (SAXException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        pushCurrToken();
+        return new ParsedDocument(pages, blocks, paragraphs, lines, tokens, lastTokenWasSpace);
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/FineReaderEventHandler.java
@@ -16,8 +16,9 @@ public class FineReaderEventHandler extends DefaultHandler {
     // Pages
     public ArrayList<AbbyyPage> pages = new ArrayList<>();
     private AbbyyPage currPage = null;
+    private String nextPageId = null;
     private String nextPageUri = null;
-    private Integer nextPageId = null;
+    private Integer nextPageIndex = null;
 
     // Block
     public ArrayList<AbbyyBlock> blocks = new ArrayList<>();
@@ -57,6 +58,7 @@ public class FineReaderEventHandler extends DefaultHandler {
                 currPage = new AbbyyPage(attributes);
                 currPage.setStart(textLength);
                 getNextPageId().ifPresent(currPage::setPageId);
+                getNextPageIndex().ifPresent(currPage::setPageIndex);
                 getNextPageUri().ifPresent(currPage::setPageUri);
                 break;
             case "block":
@@ -206,15 +208,26 @@ public class FineReaderEventHandler extends DefaultHandler {
         currToken.setEnd(textLength);
     }
 
-    public void setNextPageId(int pageId) {
+    public void setNextPageId(String pageId) {
         this.nextPageId = pageId;
     }
 
-    private Optional<Integer> getNextPageId() {
+    private Optional<String> getNextPageId() {
         if (nextPageId == null) {
             return Optional.empty();
         }
         return Optional.of(nextPageId);
+    }
+
+    public void setNextPageIndex(int pageIndex) {
+        this.nextPageIndex = pageIndex;
+    }
+
+    private Optional<Integer> getNextPageIndex() {
+        if (nextPageIndex == null) {
+            return Optional.empty();
+        }
+        return Optional.of(nextPageIndex);
     }
 
     public void setNextPageUri(String pageUri) {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyBlock.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyBlock.java
@@ -1,0 +1,46 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.texttechnologylab.annotation.ocr.abbyy.Block;
+import org.xml.sax.Attributes;
+
+public class AbbyyBlock extends AbstractStructuralAnnotation {
+    private enum BlockTypeEnum {
+        Text, Table, Picture, Barcode, Separator, SeparatorsBox, INVALID
+    }
+
+    private final BlockTypeEnum blockType;
+    private final String blockName;
+
+    public boolean valid;
+
+    public AbbyyBlock(Attributes attributes) {
+        super(attributes);
+
+        BlockTypeEnum blockType = BlockTypeEnum.INVALID;
+        try {
+            blockType = BlockTypeEnum.valueOf(attributes.getValue("blockType"));
+        } catch (IllegalArgumentException ignore) {
+            //System.err.printf("Unknown block type: %s!\n", attributes.getValue("blockType"));
+        }
+        this.blockType = blockType;
+        this.blockName = attributes.getValue("blockName");
+    }
+
+    @Override
+    public Block into(JCas jcas, int start, int end) {
+        Block block = new Block(jcas, start, end);
+        block.setTop(top);
+        block.setBottom(bottom);
+        block.setLeft(left);
+        block.setRight(right);
+        block.setBlockType(blockType.name());
+        block.setBlockName(blockName);
+        block.setValid(valid);
+        return block;
+    }
+
+    public boolean isText() {
+        return blockType == BlockTypeEnum.Text;
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyBlock.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyBlock.java
@@ -12,7 +12,6 @@ public class AbbyyBlock extends AbstractStructuralAnnotation {
     private final BlockTypeEnum blockType;
     private final String blockName;
 
-    public boolean valid;
 
     public AbbyyBlock(Attributes attributes) {
         super(attributes);
@@ -20,8 +19,8 @@ public class AbbyyBlock extends AbstractStructuralAnnotation {
         BlockTypeEnum blockType = BlockTypeEnum.INVALID;
         try {
             blockType = BlockTypeEnum.valueOf(attributes.getValue("blockType"));
-        } catch (IllegalArgumentException ignore) {
-            //System.err.printf("Unknown block type: %s!\n", attributes.getValue("blockType"));
+        } catch (IllegalArgumentException invalid) {
+            getLogger().warn("Unknown block type {}", blockType);
         }
         this.blockType = blockType;
         this.blockName = attributes.getValue("blockName");
@@ -36,7 +35,6 @@ public class AbbyyBlock extends AbstractStructuralAnnotation {
         block.setRight(right);
         block.setBlockType(blockType.name());
         block.setBlockName(blockName);
-        block.setValid(valid);
         return block;
     }
 

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyChar.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyChar.java
@@ -8,16 +8,24 @@ public class AbbyyChar extends AbstractStructuralElement {
     private final boolean isWordFromDictionary;
     private final boolean isWordNormal;
     private final boolean isWordNumeric;
+    private final boolean isTab;
     private final int suspicious;
+    private final int confidence;
 
     public String value = "";
 
     public AbbyyChar(Attributes attributes) {
         super(attributes);
+        isTab = Utils.parseBoolean(attributes.getValue("isTab"));
         isWordFromDictionary = Utils.parseBoolean(attributes.getValue("wordFromDictionary"));
         isWordNormal = Utils.parseBoolean(attributes.getValue("wordNormal"));
         isWordNumeric = Utils.parseBoolean(attributes.getValue("wordNumeric"));
         suspicious = Utils.parseBoolean(attributes.getValue("suspicious")) ? 1 : 0;
+        confidence = Utils.parseIntOr(attributes.getValue("charConfidence"), 0);
+    }
+
+    public boolean isTab() {
+        return isTab;
     }
 
     public boolean isWordFromDictionary() {
@@ -34,5 +42,9 @@ public class AbbyyChar extends AbstractStructuralElement {
 
     public int getSuspicious() {
         return suspicious;
+    }
+
+    public int getConfidence() {
+        return confidence;
     }
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyChar.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyChar.java
@@ -1,0 +1,38 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.xml.sax.Attributes;
+
+public class AbbyyChar extends AbstractStructuralElement {
+
+    private final boolean isWordFromDictionary;
+    private final boolean isWordNormal;
+    private final boolean isWordNumeric;
+    private final int suspicious;
+
+    public String value = "";
+
+    public AbbyyChar(Attributes attributes) {
+        super(attributes);
+        isWordFromDictionary = Utils.parseBoolean(attributes.getValue("wordFromDictionary"));
+        isWordNormal = Utils.parseBoolean(attributes.getValue("wordNormal"));
+        isWordNumeric = Utils.parseBoolean(attributes.getValue("wordNumeric"));
+        suspicious = Utils.parseBoolean(attributes.getValue("suspicious")) ? 1 : 0;
+    }
+
+    public boolean isWordFromDictionary() {
+        return isWordFromDictionary;
+    }
+
+    public boolean isWordNormal() {
+        return isWordNormal;
+    }
+
+    public boolean isWordNumeric() {
+        return isWordNumeric;
+    }
+
+    public int getSuspicious() {
+        return suspicious;
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyDocument.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyDocument.java
@@ -1,0 +1,48 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import com.google.common.base.Strings;
+import org.apache.uima.jcas.JCas;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.texttechnologylab.annotation.ocr.abbyy.Document;
+import org.xml.sax.Attributes;
+
+public class AbbyyDocument extends AbstractAnnotation {
+
+    // Mandatory
+    private final String version;
+    private final String producer;
+
+    // Optional
+    private final Integer pagesCount;
+    private final String mainLanguage;
+    private final String languages;
+
+    // Additional
+    public String documentName;
+
+    public AbbyyDocument(Attributes attributes) {
+        this.version = attributes.getValue("version");
+        this.producer = attributes.getValue("producer");
+        this.pagesCount = Utils.parseIntOr(attributes.getValue("pagesCount"), 1);
+        this.mainLanguage = Strings.nullToEmpty(attributes.getValue("mainLanguage"));
+        this.languages = Strings.nullToEmpty(attributes.getValue("languages"));
+    }
+
+    public void setDocumentName(String documentName) {
+        this.documentName = documentName;
+    }
+
+    @Override
+    public Document into(JCas jcas, int start, int end) {
+        Document document = new Document(jcas, start, end);
+        document.setVersion(version);
+        document.setProducer(producer);
+        document.setPagesCount(pagesCount);
+        document.setMainLanguage(mainLanguage);
+        document.setLanguages(languages);
+        if (documentName != null) {
+            document.setDocumentName(documentName);
+        }
+        return document;
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyFormat.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyFormat.java
@@ -1,0 +1,48 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.xml.sax.Attributes;
+import org.texttechnologylab.annotation.ocr.abbyy.Format;
+
+public class AbbyyFormat extends AbstractAnnotation {
+    private final String lang;
+    private final String ff;
+    private final float fs;
+    private final boolean bold;
+    private final boolean italic;
+    private final boolean subscript;
+    private final boolean superscript;
+    private final boolean smallcaps;
+    private final boolean underline;
+    private final boolean strikeout;
+
+    public AbbyyFormat(Attributes attributes) {
+        this.lang = attributes.getValue("lang");
+        this.ff = attributes.getValue("ff");
+        this.fs = Utils.parseFloat(attributes.getValue("fs"));
+        this.bold = Utils.parseBoolean(attributes.getValue("bold"));
+        this.italic = Utils.parseBoolean(attributes.getValue("italic"));
+        this.subscript = Utils.parseBoolean(attributes.getValue("subscript"));
+        this.superscript = Utils.parseBoolean(attributes.getValue("superscript"));
+        this.smallcaps = Utils.parseBoolean(attributes.getValue("smallcaps"));
+        this.underline = Utils.parseBoolean(attributes.getValue("underline"));
+        this.strikeout = Utils.parseBoolean(attributes.getValue("strikeout"));
+    }
+
+    @Override
+    public Format into(JCas jCas, int start, int end) {
+        Format format = new Format(jCas, start, end);
+        format.setLang(lang);
+        format.setFf(ff);
+        format.setFs(fs);
+        format.setBold(bold);
+        format.setItalic(italic);
+        format.setSubscript(subscript);
+        format.setSuperscript(superscript);
+        format.setSmallcaps(smallcaps);
+        format.setUnderline(underline);
+        format.setStrikeout(strikeout);
+        return format;
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyLine.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyLine.java
@@ -28,8 +28,10 @@ public class AbbyyLine extends AbstractStructuralAnnotation {
 
     public void setFormat(AbbyyFormat format) {
         this.format = format;
-        this.format.setStart(start);
-        this.format.setEnd(end);
+        if (this.format != null) {
+            this.format.setStart(start);
+            this.format.setEnd(end);
+        }
     }
 
     @Override

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyLine.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyLine.java
@@ -1,0 +1,42 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.texttechnologylab.annotation.ocr.abbyy.Line;
+import org.xml.sax.Attributes;
+
+public class AbbyyLine extends AbstractStructuralAnnotation {
+    private final int baseline;
+
+    // FIXME: Evaluate whether there are lines with multiple <formatting> tags!
+    public AbbyyFormat format;
+
+    public AbbyyLine(Attributes attributes) {
+        super(attributes);
+        this.baseline = Utils.parseInt(attributes.getValue("baseline"));
+    }
+
+    @Override
+    public Line into(JCas jcas, int start, int end) {
+        Line line = new Line(jcas, start, end);
+        line.setBaseline(baseline);
+        if (format != null) {
+            line.setFormat(format.into(jcas, start, end));
+        }
+        return line;
+    }
+
+    public void setFormat(AbbyyFormat format) {
+        this.format = format;
+        this.format.setStart(start);
+        this.format.setEnd(end);
+    }
+
+    @Override
+    public void setEnd(int end) {
+        super.setEnd(end);
+        if (format != null) {
+            format.setEnd(end);
+        }
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
@@ -9,6 +9,7 @@ public class AbbyyPage extends AbstractAnnotation {
     private final Integer width;
     private final Integer height;
     private final Integer resolution;
+    private Orientation rotation = Orientation.Normal;
     //private final boolean originalCoords;
 
     public String pageId;
@@ -20,6 +21,9 @@ public class AbbyyPage extends AbstractAnnotation {
         this.width = Utils.parseInt(attributes.getValue("width"));
         this.height = Utils.parseInt(attributes.getValue("height"));
         this.resolution = Utils.parseInt(attributes.getValue("resolution"));
+        if (attributes.getValue("rotation") != null) {
+            this.rotation = Orientation.valueOf(attributes.getValue("rotation"));
+        }
         //this.originalCoords = TypeParser.parseBoolean(attributes.getValue("originalCoords"));
     }
 
@@ -41,6 +45,7 @@ public class AbbyyPage extends AbstractAnnotation {
         page.setHeight(height);
         page.setWidth(width);
         page.setResolution(resolution);
+        page.setRotation(rotation.name());
         return page;
     }
 

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
@@ -1,0 +1,54 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.texttechnologylab.annotation.ocr.abbyy.Page;
+import org.xml.sax.Attributes;
+
+public class AbbyyPage extends AbstractAnnotation {
+    private final Integer width;
+    private final Integer height;
+    private final Integer resolution;
+    //private final boolean originalCoords;
+
+    public String pageUri;
+    public Integer pageId;
+    public String pageNumber;
+
+    public AbbyyPage(Attributes attributes) {
+        this.width = Utils.parseInt(attributes.getValue("width"));
+        this.height = Utils.parseInt(attributes.getValue("height"));
+        this.resolution = Utils.parseInt(attributes.getValue("resolution"));
+        //this.originalCoords = TypeParser.parseBoolean(attributes.getValue("originalCoords"));
+    }
+
+    @Override
+    public Page into(JCas jcas, int start, int end) {
+        Page page = new Page(jcas, start, end);
+        if (pageId != null) {
+            page.setId(pageId);
+        }
+        if (pageUri != null) {
+            page.setUri(pageUri);
+        }
+        if (pageNumber != null) {
+            page.setNumber(pageNumber);
+        }
+        page.setHeight(height);
+        page.setWidth(width);
+        page.setResolution(resolution);
+        return page;
+    }
+
+    public void setPageUri(String pageUri) {
+        this.pageUri = pageUri;
+    }
+
+    public void setPageId(Integer pageId) {
+        this.pageId = pageId;
+    }
+
+    public void setPageNumber(String pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
@@ -11,8 +11,9 @@ public class AbbyyPage extends AbstractAnnotation {
     private final Integer resolution;
     //private final boolean originalCoords;
 
+    public String pageId;
     public String pageUri;
-    public Integer pageId;
+    public Integer pageIndex;
     public String pageNumber;
 
     public AbbyyPage(Attributes attributes) {
@@ -31,8 +32,11 @@ public class AbbyyPage extends AbstractAnnotation {
         if (pageUri != null) {
             page.setUri(pageUri);
         }
+        if (pageIndex != null) {
+            page.setIndex(pageIndex);
+        }
         if (pageNumber != null) {
-            page.setNumber(pageNumber);
+            page.setPageNumber(pageNumber);
         }
         page.setHeight(height);
         page.setWidth(width);
@@ -40,12 +44,17 @@ public class AbbyyPage extends AbstractAnnotation {
         return page;
     }
 
+    public void setPageId(String pageId) {
+        this.pageId = pageId;
+    }
+
+
     public void setPageUri(String pageUri) {
         this.pageUri = pageUri;
     }
 
-    public void setPageId(Integer pageId) {
-        this.pageId = pageId;
+    public void setPageIndex(Integer pageIndex) {
+        this.pageIndex = pageIndex;
     }
 
     public void setPageNumber(String pageNumber) {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyPage.java
@@ -60,4 +60,12 @@ public class AbbyyPage extends AbstractAnnotation {
     public void setPageNumber(String pageNumber) {
         this.pageNumber = pageNumber;
     }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyParagraph.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyParagraph.java
@@ -1,0 +1,47 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.assertj.core.util.Strings;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.texttechnologylab.annotation.ocr.abbyy.Paragraph;
+import org.xml.sax.Attributes;
+
+public class AbbyyParagraph extends AbstractAnnotation {
+    private enum Alignment {
+        Left, Center, Right, Justified
+    }
+
+    private final int leftIndent;
+    private final int rightIndent;
+    private final int startIndent;
+    private final int lineSpacing;
+    private final Alignment alignment;
+
+    public AbbyyParagraph(Attributes attributes) {
+        this.leftIndent = Utils.parseInt(attributes.getValue("leftIndent"));
+        this.rightIndent = Utils.parseInt(attributes.getValue("rightIndent"));
+        this.startIndent = Utils.parseInt(attributes.getValue("startIndent"));
+        this.lineSpacing = Utils.parseInt(attributes.getValue("lineSpacing"));
+
+        Alignment alignment = Alignment.Left;
+        try {
+            String align = attributes.getValue("align");
+            if (!Strings.isNullOrEmpty(align)) {
+                alignment = Alignment.valueOf(align);
+            }
+        } catch (IllegalArgumentException ignore) {
+        }
+        this.alignment = alignment;
+    }
+
+    @Override
+    public Paragraph into(JCas jcas, int start, int end) {
+        Paragraph paragraph = new Paragraph(jcas, start, end);
+        paragraph.setLeftIndent(leftIndent);
+        paragraph.setRightIndent(rightIndent);
+        paragraph.setStartIndent(startIndent);
+        paragraph.setLineSpacing(lineSpacing);
+        paragraph.setAlignment(alignment.name());
+        return paragraph;
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 public class AbbyyToken extends AbstractAnnotation {
     private static final AbbyyToken SPACE = new AbbyyToken(" ");
+    private static final AbbyyToken TAB = new AbbyyToken("\t");
     private static final AbbyyToken NEWLINE = new AbbyyToken("\n");
 
     private ArrayList<StringBuilder> subTokenList = new ArrayList<>(List.of(new StringBuilder()));
@@ -64,6 +65,10 @@ public class AbbyyToken extends AbstractAnnotation {
 
     public static AbbyyToken space() {
         return SPACE;
+    }
+
+    public static AbbyyToken tab() {
+        return TAB;
     }
 
     public static AbbyyToken newline() {

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
@@ -31,6 +31,8 @@ public class AbbyyToken extends AbstractAnnotation {
             token.setIsWordFromDictionary(charList.stream().anyMatch(AbbyyChar::isWordFromDictionary));
             token.setIsWordNormal(charList.stream().anyMatch(AbbyyChar::isWordNormal));
             token.setIsWordNumeric(charList.stream().anyMatch(AbbyyChar::isWordNumeric));
+            token.setMeanCharConfidence((float) charList.stream().mapToInt(AbbyyChar::getConfidence).average().orElse(-1));
+            token.setMinCharConfidence((short) charList.stream().mapToInt(AbbyyChar::getConfidence).min().orElse(-1));
         }
         if (subTokenList.size() > 1) {
             token.setContainsHyphen(true);

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
@@ -28,12 +28,12 @@ public class AbbyyToken extends AbstractAnnotation {
         Token token = new Token(jcas, start, end);
         if (charList != null && !charList.isEmpty()) {
             token.setSuspiciousChars(charList.stream().mapToInt(AbbyyChar::getSuspicious).sum());
-            token.setIsWordFromDictionary(charList.getLast().isWordFromDictionary());
-            token.setIsWordNormal(charList.getLast().isWordNormal());
-            token.setIsWordNumeric(charList.getLast().isWordNumeric());
+            token.setIsWordFromDictionary(charList.stream().anyMatch(AbbyyChar::isWordFromDictionary));
+            token.setIsWordNormal(charList.stream().anyMatch(AbbyyChar::isWordNormal));
+            token.setIsWordNumeric(charList.stream().anyMatch(AbbyyChar::isWordNumeric));
         }
         if (subTokenList.size() > 1) {
-            token.setContainsHyphen(false);
+            token.setContainsHyphen(true);
             token.setSubTokenList(StringList.create(jcas, subTokenList.stream().map(StringBuilder::toString).toArray(String[]::new)));
         }
         return token;
@@ -69,7 +69,7 @@ public class AbbyyToken extends AbstractAnnotation {
     }
 
     public boolean isSpace() {
-        return subTokenList == null || subTokenList.stream().anyMatch(s -> !s.toString().isBlank());
+        return subTokenList == null || subTokenList.stream().allMatch(s -> s.toString().isBlank());
     }
 
     @Override

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbbyyToken.java
@@ -1,0 +1,79 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.cas.StringList;
+import org.texttechnologylab.annotation.ocr.abbyy.Token;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class AbbyyToken extends AbstractAnnotation {
+    private static final AbbyyToken SPACE = new AbbyyToken(" ");
+    private static final AbbyyToken NEWLINE = new AbbyyToken("\n");
+
+    private ArrayList<StringBuilder> subTokenList = new ArrayList<>(List.of(new StringBuilder()));
+    private ArrayList<AbbyyChar> charList;
+
+    public AbbyyToken() {
+    }
+
+    public AbbyyToken(String text) {
+        this.addChar(null, text);
+    }
+
+    @Override
+    public Token into(JCas jcas, int start, int end) {
+        Token token = new Token(jcas, start, end);
+        if (charList != null && !charList.isEmpty()) {
+            token.setSuspiciousChars(charList.stream().mapToInt(AbbyyChar::getSuspicious).sum());
+            token.setIsWordFromDictionary(charList.getLast().isWordFromDictionary());
+            token.setIsWordNormal(charList.getLast().isWordNormal());
+            token.setIsWordNumeric(charList.getLast().isWordNumeric());
+        }
+        if (subTokenList.size() > 1) {
+            token.setContainsHyphen(false);
+            token.setSubTokenList(StringList.create(jcas, subTokenList.stream().map(StringBuilder::toString).toArray(String[]::new)));
+        }
+        return token;
+    }
+
+    public void addChar(AbbyyChar abbyyChar, String text) {
+        if (abbyyChar != null) {
+            if (charList == null) {
+                charList = new ArrayList<>();
+            }
+            charList.add(abbyyChar);
+        }
+        subTokenList.getLast().append(text);
+    }
+
+    public void addSubToken() {
+        if (subTokenList == null) {
+            subTokenList = new ArrayList<>();
+        }
+        subTokenList.add(new StringBuilder());
+    }
+
+    public int length() {
+        return subTokenList == null ? 0 : subTokenList.stream().map(StringBuilder::length).reduce(0, Integer::sum);
+    }
+
+    public static AbbyyToken space() {
+        return SPACE;
+    }
+
+    public static AbbyyToken newline() {
+        return NEWLINE;
+    }
+
+    public boolean isSpace() {
+        return subTokenList == null || subTokenList.stream().anyMatch(s -> !s.toString().isBlank());
+    }
+
+    @Override
+    public String toString() {
+        return subTokenList.stream().map(StringBuilder::toString).collect(Collectors.joining(""));
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractAnnotation.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractAnnotation.java
@@ -1,7 +1,9 @@
 package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
 
+import org.apache.uima.UIMAFramework;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.util.Logger;
 
 
 abstract public class AbstractAnnotation implements IIntoAnnotation {
@@ -22,5 +24,9 @@ abstract public class AbstractAnnotation implements IIntoAnnotation {
 
     public Annotation into(JCas jCas, int offset) {
         return into(jCas, start + offset, end + offset);
+    }
+
+    public Logger getLogger() {
+        return UIMAFramework.getLogger(this.getClass());
     }
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractAnnotation.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractAnnotation.java
@@ -1,0 +1,26 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+
+
+abstract public class AbstractAnnotation implements IIntoAnnotation {
+    public int start = 0;
+    public int end = 0;
+
+    public void setStart(int start) {
+        this.start = start;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    public Annotation into(JCas jCas) {
+        return into(jCas, start, end);
+    }
+
+    public Annotation into(JCas jCas, int offset) {
+        return into(jCas, start + offset, end + offset);
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralAnnotation.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralAnnotation.java
@@ -1,0 +1,34 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.xml.sax.Attributes;
+
+abstract public class AbstractStructuralAnnotation extends AbstractStructuralElement implements IIntoAnnotation {
+    public int start = 0;
+    public int end = 0;
+
+    public AbstractStructuralAnnotation(Attributes attributes) {
+        super(attributes);
+    }
+
+    public void setStart(int start) {
+        this.start = start;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    public Annotation into(JCas jCas) {
+        return into(jCas, start, end);
+    }
+
+    public Annotation into(JCas jCas, int offset) {
+        return into(jCas, start + offset, end + offset);
+    }
+
+    public boolean insideBoundingBox(int top, int right, int bottom, int left) {
+        return this.top >= top && this.right <= right && this.bottom <= bottom && this.left >= left;
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralElement.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralElement.java
@@ -3,6 +3,7 @@ package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.ele
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.util.Logger;
 import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.bb.Rect;
 import org.xml.sax.Attributes;
 
 abstract public class AbstractStructuralElement {
@@ -20,5 +21,12 @@ abstract public class AbstractStructuralElement {
 
     public Logger getLogger() {
         return UIMAFramework.getLogger(this.getClass());
+    }
+
+    /**
+     * @return The bounding box {@link Rect rectangle} for this element.
+     */
+    public Rect getRect() {
+        return new Rect(top, right, bottom, left);
     }
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralElement.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralElement.java
@@ -1,0 +1,18 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
+import org.xml.sax.Attributes;
+
+abstract public class AbstractStructuralElement {
+    final int top;
+    final int bottom;
+    final int left;
+    final int right;
+
+    public AbstractStructuralElement(Attributes attributes) {
+        this.top = Utils.parseInt(attributes.getValue("t"));
+        this.bottom = Utils.parseInt(attributes.getValue("b"));
+        this.left = Utils.parseInt(attributes.getValue("l"));
+        this.right = Utils.parseInt(attributes.getValue("r"));
+    }
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralElement.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/AbstractStructuralElement.java
@@ -1,5 +1,7 @@
 package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
 
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.util.Logger;
 import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.utils.Utils;
 import org.xml.sax.Attributes;
 
@@ -14,5 +16,9 @@ abstract public class AbstractStructuralElement {
         this.bottom = Utils.parseInt(attributes.getValue("b"));
         this.left = Utils.parseInt(attributes.getValue("l"));
         this.right = Utils.parseInt(attributes.getValue("r"));
+    }
+
+    public Logger getLogger() {
+        return UIMAFramework.getLogger(this.getClass());
     }
 }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/IIntoAnnotation.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/IIntoAnnotation.java
@@ -1,0 +1,16 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+
+public interface IIntoAnnotation {
+    public void setStart(int start);
+
+    public void setEnd(int end);
+
+    Annotation into(JCas jcas, int start, int end);
+
+    public Annotation into(JCas jCas);
+
+    public Annotation into(JCas jCas, int offset);
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/Orientation.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/reader/abbyy/xml/elements/Orientation.java
@@ -1,0 +1,8 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.xml.elements;
+
+public enum Orientation {
+    Normal,
+    RotatedClockwise,
+    RotatedUpsidedown,
+    RotatedCounterclockwise
+}

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/monitoring/ProgressTracker.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/monitoring/ProgressTracker.java
@@ -1,0 +1,86 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.monitoring;
+
+import org.apache.uima.util.Progress;
+
+public class ProgressTracker implements Progress {
+        private long completed;
+        private long total;
+        private String unit;
+        private final boolean approximate;
+
+        public ProgressTracker(long total, String unit, boolean approximate) {
+            this.setTotal(total);
+            this.completed = 0;
+            this.unit = unit;
+            this.approximate = approximate;
+        }
+
+        public ProgressTracker(long total, String unit) {
+            this(total, unit, false);
+        }
+
+        public ProgressTracker(long total) {
+            this(total, "items", false);
+        }
+
+        @Override
+        public long getCompleted() {
+            return this.completed;
+        }
+
+        public void setTotal(long value) throws IllegalArgumentException {
+            if (value <= 0) {
+                throw new IllegalArgumentException("Total must be > 0!");
+            }
+            this.total = value;
+        }
+
+        public void setCompleted(long value) throws IllegalArgumentException {
+            if (value < 0 || value > getTotal()) {
+                throw new IllegalArgumentException("completed must be >= 0 and <= total!");
+            }
+            this.completed = value;
+        }
+
+        @Override
+        public long getTotal() {
+            return this.total;
+        }
+
+        @Override
+        public String getUnit() {
+            return this.unit;
+        }
+
+        public void setUnit(String value) {
+            this.unit = value;
+        }
+
+        @Override
+        public boolean isApproximate() {
+            return this.approximate;
+        }
+
+        public void inc() {
+            this.completed += 1;
+        }
+
+        public void increment(long by) {
+            this.completed += by;
+        }
+
+        @Override
+        public String toString() {
+            String format = String.format("% 4.0f%% [%s/%d %s]", getCompleted() * 100f / getTotal(), getCompletedF(), getTotal(), getUnit());
+            if (isApproximate()) {
+                format += " (approximate)";
+            }
+            return format;
+        }
+
+        protected String getCompletedF() {
+            int digits = 1 + (int) Math.log10(getTotal());
+            String format = "%" + digits + "d";
+            return String.format(format, getCompleted());
+        }
+    }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/monitoring/ProgressTrackerRemaining.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/monitoring/ProgressTrackerRemaining.java
@@ -1,0 +1,49 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.monitoring;
+
+import java.time.Duration;
+
+public class ProgressTrackerRemaining extends ProgressTracker {
+        private final long start = System.currentTimeMillis();
+
+        public ProgressTrackerRemaining(long total, String unit, boolean approximate) {
+            super(total, unit, approximate);
+        }
+
+        public ProgressTrackerRemaining(long total, String unit) {
+            super(total, unit, false);
+        }
+
+        public ProgressTrackerRemaining(long total) {
+            super(total, "items", false);
+        }
+
+        @Override
+        public String toString() {
+            long total = getTotal();
+            long completed = getCompleted();
+            double millisPassed = System.currentTimeMillis() - start * 1d;
+            double millisEstimated = millisPassed / completed * total;
+            long millisRemaining = (long) (millisEstimated - millisPassed);
+
+            String remaining;
+            Duration durationRemaining = Duration.ofMillis(millisRemaining);
+            if (durationRemaining.toHours() > 0) {
+                long hours = durationRemaining.toHours();
+                long minutes = durationRemaining.minusHours(hours).toMinutes();
+                long seconds = durationRemaining.minusHours(hours).minusMinutes(minutes).toSeconds();
+                remaining = String.format("%dh %2dm %2ds", hours, minutes, seconds);
+            } else if (durationRemaining.toMinutes() > 0) {
+                long minutes = durationRemaining.toMinutes();
+                long seconds = durationRemaining.minusMinutes(minutes).toSeconds();
+                remaining = String.format("%dm %2ds", minutes, seconds);
+            } else {
+                remaining = String.format("%2ds", durationRemaining.toSeconds());
+            }
+
+            String format = String.format("% 4.0f%% [%s/%d %s, %s]", completed * 100f / total, getCompletedF(), total, getUnit(), remaining);
+            if (isApproximate()) {
+                format += " (approximate)";
+            }
+            return format;
+        }
+    }

--- a/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/tools/ViewCreator.java
+++ b/src/main/java/org/texttechnologylab/DockerUnifiedUIMAInterface/tools/ViewCreator.java
@@ -1,0 +1,126 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.tools;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.uima.UimaContext;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.cas.Type;
+import org.apache.uima.fit.component.JCasAnnotator_ImplBase;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceInitializationException;
+
+/**
+ * @param PARAM_TARGET_VIEW   Name of the target view to create, mandatory.
+ * @param PARAM_SOURCE_VIEW   Name of the source view to copy from (if any),
+ *                            optional, default: {@code _InitialView}.
+ * @param PARAM_TYPES_TO_COPY List of types to copy from the source view,
+ *                            optional.
+ * @param PARAM_EXIST_OKAY    If false, raise an error if the target view
+ *                            already exists, optional, default: {@code true}.
+ */
+public class ViewCreator extends JCasAnnotator_ImplBase {
+
+    /**
+     * Name of the target view to create.
+     */
+    public static final String PARAM_TARGET_VIEW = "targetView";
+    @ConfigurationParameter(name = PARAM_TARGET_VIEW, mandatory = true)
+    private String paramTargetView;
+
+    /**
+     * Name of the source view to copy from (if any).
+     * Defaults to "_InitialView".
+     */
+    public static final String PARAM_SOURCE_VIEW = "sourceView";
+    @ConfigurationParameter(name = PARAM_SOURCE_VIEW, mandatory = false, defaultValue = "_InitialView")
+    private String paramSourceView;
+
+    /**
+     * The types to copy from the source view.
+     * Must be a list of the fully qualified class name of the types.
+     * 
+     * @apiNote You can use the
+     *          {@link org.apache.uima.jcas.cas.TOP#_TypeName _TypeName} field of
+     *          any {@link org.apache.uima.jcas.tcas.Annotation annotation} to
+     *          access the fully qualified class name for convenience.
+     */
+    public static final String PARAM_TYPES_TO_COPY = "typesToCopy";
+    @ConfigurationParameter(name = PARAM_TYPES_TO_COPY, mandatory = false, defaultValue = {})
+    private String[] paramTypesToCopy;
+
+    /**
+     * Name of the source view to copy from (if any).
+     * Defaults to "_InitialView".
+     */
+    public static final String PARAM_EXIST_OKAY = "existOkay";
+    @ConfigurationParameter(name = PARAM_EXIST_OKAY, mandatory = false, defaultValue = "true")
+    private Boolean paramExistOkay;
+
+    private HashSet<String> typeSet = new HashSet<>();
+
+    /**
+     * @return An immutable copy of the {@link #typesToCopy}.
+     * @apiNote The returned set can only be empty prior to
+     *          {@link #initialize initialization}.
+     */
+    public Set<String> getTypeSet() {
+        return Set.copyOf(this.typeSet);
+    }
+
+    /**
+     * Initializes the annotator.
+     * 
+     * You can either drop or retain specific types from the CAS.
+     * The mode of operations is determined automatically based on the
+     * configuration.
+     * 
+     * @throws ResourceInitializationException If {@link #PARAM_TARGET_VIEW} is
+     *                                         empty.
+     */
+    @Override
+    public void initialize(UimaContext context) throws ResourceInitializationException {
+        super.initialize(context);
+
+        if (this.paramTargetView.isEmpty()) {
+            throw new ResourceInitializationException(
+                    new IllegalArgumentException("The target view cannot be empty!"));
+        }
+
+        this.typeSet = new HashSet<>(List.of(this.paramTypesToCopy));
+    }
+
+    @Override
+    public void process(JCas aJCas) throws AnalysisEngineProcessException {
+        final JCas targetView = this.creatOrGetTargetView(aJCas, this.paramTargetView);
+        for (String typeName : this.typeSet) {
+            Type type = aJCas.getTypeSystem().getType(typeName);
+            aJCas.select(type).forEach(a -> {
+                targetView.getIndexRepository().addFS(a);
+            });
+        }
+    }
+
+    private JCas creatOrGetTargetView(JCas aJCas, String targetViewName) throws AnalysisEngineProcessException {
+        try {
+            JCas view = aJCas.createView(targetViewName);
+            view.setDocumentText(aJCas.getDocumentText());
+            view.setDocumentLanguage(aJCas.getDocumentLanguage());
+            return view;
+        } catch (CASException createException) {
+            if (!this.paramExistOkay) {
+                throw new AnalysisEngineProcessException(createException);
+            } else {
+                try {
+                    return aJCas.getView(targetViewName);
+                } catch (CASException getException) {
+                    throw new AnalysisEngineProcessException(getException);
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/abbyy/TestAbbyyDocumentReader.java
+++ b/src/test/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/abbyy/TestAbbyyDocumentReader.java
@@ -22,8 +22,9 @@ public class TestAbbyyDocumentReader {
         try {
             CollectionReader reader = CollectionReaderFactory.createReader(AbbyyDocumentReader.class,
                     AbbyyDocumentReader.PARAM_SOURCE_LOCATION, path,
-                    AbbyyDocumentReader.PARAM_ROOT_PATTERNS, "[+]*",
+                    AbbyyDocumentReader.PARAM_ROOT_PATTERNS, "[+]**/",
                     AbbyyDocumentReader.PARAM_FILE_PATTERNS, "[+]**/*.xml*",
+                    AbbyyDocumentReader.PARAM_DOCUMENT_ID_PATTERN, ".*/(\\d+)/?|(\\d+)[^/]*",
                     // URI for UB Biodiversity corpus
                     AbbyyDocumentReader.PARAM_BASE_URI, "https://sammlungen.ub.uni-frankfurt.de/biodiv/",
                     // relative "inner" bounding box, inset to 1% of each pages' dimensions

--- a/src/test/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/abbyy/TestAbbyyDocumentReader.java
+++ b/src/test/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/abbyy/TestAbbyyDocumentReader.java
@@ -23,8 +23,13 @@ public class TestAbbyyDocumentReader {
             CollectionReader reader = CollectionReaderFactory.createReader(AbbyyDocumentReader.class,
                     AbbyyDocumentReader.PARAM_SOURCE_LOCATION, path,
                     AbbyyDocumentReader.PARAM_ROOT_PATTERNS, "[+]*",
-                    AbbyyDocumentReader.PARAM_FILE_PATTERNS, "[+]**/*.xml.*",
-                    AbbyyDocumentReader.PARAM_BASE_URI, "https://sammlungen.ub.uni-frankfurt.de/biodiv/"
+                    AbbyyDocumentReader.PARAM_FILE_PATTERNS, "[+]**/*.xml*",
+                    // URI for UB Biodiversity corpus
+                    AbbyyDocumentReader.PARAM_BASE_URI, "https://sammlungen.ub.uni-frankfurt.de/biodiv/",
+                    // relative "inner" bounding box, inset to 1% of each pages' dimensions
+                    AbbyyDocumentReader.PARAM_BOUNDING_BOX_DEF, "1",
+                    // omit line format annotations
+                    AbbyyDocumentReader.PARAM_ADD_LINE_FORMAT, false
             );
             AnalysisEngineDescription writer = AnalysisEngineFactory.createEngineDescription(
                     XmiWriter.class,

--- a/src/test/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/abbyy/TestAbbyyDocumentReader.java
+++ b/src/test/java/org/texttechnologylab/DockerUnifiedUIMAInterface/io/abbyy/TestAbbyyDocumentReader.java
@@ -1,0 +1,41 @@
+package org.texttechnologylab.DockerUnifiedUIMAInterface.io.abbyy;
+
+import org.apache.uima.UIMAException;
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.collection.CollectionReader;
+import org.apache.uima.fit.factory.AnalysisEngineFactory;
+import org.apache.uima.fit.factory.CollectionReaderFactory;
+import org.apache.uima.fit.pipeline.SimplePipeline;
+import org.dkpro.core.io.xmi.XmiWriter;
+import org.junit.Test;
+import org.texttechnologylab.DockerUnifiedUIMAInterface.io.reader.abbyy.AbbyyDocumentReader;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+public class TestAbbyyDocumentReader {
+
+    @Test
+    public void testReader() {
+        String path = Paths.get("src/test/resources/Biodiversity/").toAbsolutePath().toString();
+
+        try {
+            CollectionReader reader = CollectionReaderFactory.createReader(AbbyyDocumentReader.class,
+                    AbbyyDocumentReader.PARAM_SOURCE_LOCATION, path,
+                    AbbyyDocumentReader.PARAM_ROOT_PATTERNS, "[+]*",
+                    AbbyyDocumentReader.PARAM_FILE_PATTERNS, "[+]**/*.xml.*",
+                    AbbyyDocumentReader.PARAM_BASE_URI, "https://sammlungen.ub.uni-frankfurt.de/biodiv/"
+            );
+            AnalysisEngineDescription writer = AnalysisEngineFactory.createEngineDescription(
+                    XmiWriter.class,
+                    XmiWriter.PARAM_TARGET_LOCATION, "/tmp/duui/io/abbyy/",
+                    XmiWriter.PARAM_PRETTY_PRINT, true,
+                    XmiWriter.PARAM_OVERWRITE, true,
+                    XmiWriter.PARAM_SANITIZE_ILLEGAL_CHARACTERS, true
+            );
+            SimplePipeline.runPipeline(reader, writer);
+        } catch (UIMAException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements a new `Reader` class for ABBYY FineReader OCR files (as used in the BIOfid project) up to version 10.
It is designed in tandem to [PR#48 in the UIMATypeSystem repo](https://github.com/texttechnologylab/UIMATypeSystem/pull/48).

The new reader class features many parameters and a vastly improved implementation in comparison to the legacy TextImager implementation.
It allows to specify a `sourceLocation` a pattern for `root` directories and a separate pattern for ABBYY FineReader XML files, handles compressed XML files, allows to set a "inner bounding box" to exclude elements on the edges of pages, setting of metadata including URIs down to the page level, toggling the inclusion of all levels of structural elements, and more.

To remain independent of potential breaking changes in the type system, a set of utility classes were added that provide an intermediate representation to the XML elements.